### PR TITLE
Handle TrimmedDataAccessException errors

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+.git/
+.github/
+.gitmodules
+.idea/
+.travis.yml
+.vscode/
+test/

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dynamodb-subscriber",
+  "name": "@replicon/dynamodb-subscriber",
   "description": "",
   "version": "1.2.0",
   "author": "Andrew Ovens <andrew.ovens@replicon.com>",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "dynamodb-subscriber",
   "description": "",
-  "version": "1.1.2",
-  "author": "José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)",
+  "version": "1.2.0",
+  "author": "Andrew Ovens <andrew.ovens@replicon.com>",
   "repository": {
-    "url": "git://github.com/jfromaniello/dynamodb-subscriber.git"
+    "url": "git://github.com/replicon/dynamodb-subscriber.git"
   },
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@replicon/dynamodb-subscriber",
+  "name": "dynamodb-subscriber",
   "description": "",
-  "version": "1.5.0",
-  "author": "Andrew Ovens <andrew.ovens@replicon.com>",
+  "version": "1.1.2",
+  "author": "José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)",
   "repository": {
-    "url": "git://github.com/replicon/dynamodb-subscriber.git"
+    "url": "git://github.com/jfromaniello/dynamodb-subscriber.git"
   },
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replicon/dynamodb-subscriber",
   "description": "",
-  "version": "1.2.0",
+  "version": "1.5.0",
   "author": "Andrew Ovens <andrew.ovens@replicon.com>",
   "repository": {
     "url": "git://github.com/replicon/dynamodb-subscriber.git"


### PR DESCRIPTION
This PR should add the ability for this library to correctly and gracefully handle TrimmedDataAccessException errors which arise when no dynamo activity occurs for 24 hours or when subscribing to a stream on a newly created table