### PR TITLE
SF-2432: Migrate from AWS SDK v2 to v3

### DIFF
--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -1,0 +1,45 @@
+on:
+  pull_request: {}
+  push:
+    branches:
+    - main
+    - master
+name: Checkmarx SAST Scan
+jobs:
+  checkmarx-scan:
+        name: Checkmarx SAST Scan
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+
+        steps:
+            - name: Checkout Code
+              uses: actions/checkout@v4
+
+            - name: Run Checkmarx SAST Scan
+              uses: checkmarx-ts/checkmarx-cxflow-github-action@v2.3
+              with:
+                # Connection parameters
+                checkmarx_url: https://cmxext.deltek.com
+                checkmarx_username: ${{ secrets.CHECKMARX_USERNAME }}
+                checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
+                checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
+                team: "/CxServer/Security/Deltek/Replicon"
+
+                # Project configuration
+                project: Replicon-${{ github.event.repository.name }}
+                scanners: sast
+                # bug_tracker: GitHub
+                incremental: false
+                break_build: false
+
+                # Scan parameters and thresholds
+                params: >-
+                  --namespace=${{ github.repository_owner}}
+                  --checkmarx.settings-override=true
+                  --repo-name=${{ github.event.repository.name}}
+                  --branch=${{ github.ref_name || github.head_ref}}
+                  --cx-flow.filterSeverity
+                  --cx-flow.thresholds.high=1
+                  --cx-flow.thresholds.medium=1
+                  ${{ github.event.number && format('--merge-id={0}', github.event.number)}}
+                  

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -41,5 +41,6 @@ jobs:
                   --cx-flow.filterSeverity
                   --cx-flow.thresholds.high=1
                   --cx-flow.thresholds.medium=1
+                  --cx-flow.scan-resubmit=true
                   ${{ github.event.number && format('--merge-id={0}', github.event.number)}}
                   

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -9,88 +9,14 @@ on:
   workflow_dispatch:
 name: Checkmarx SAST Scan
 jobs:
-  checkmarx-scan:
-        name: Checkmarx SAST Scan
-        runs-on: ubuntu-latest
-        concurrency:
-            group: checkmarx-${{ github.head_ref || github.ref }}
-            cancel-in-progress: true
-        timeout-minutes: 90
-        if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
+  call-reusable-checkmarx:
+    name: Call Reusable Checkmarx Workflow
+    uses: Replicon/time-intelligence-web/.github/workflows/reusable-checkmarx.yml@main
+    with:
+      timeout_minutes: 90
+      scheduled_timeout_minutes: 360
+    secrets:
+      checkmarx_username: ${{ secrets.CHECKMARX_USERNAME }}
+      checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
+      checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
 
-        steps:
-          - name: Checkout Code
-            uses: actions/checkout@v4
-
-          - name: Run Checkmarx SAST Scan
-            uses: checkmarx-ts/checkmarx-cxflow-github-action@v2.3
-            with:
-              # Connection parameters
-              checkmarx_url: https://cmxext.deltek.com
-              checkmarx_username: ${{ secrets.CHECKMARX_USERNAME }}
-              checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
-              checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
-              team: "/CxServer/Security/Deltek/Replicon"
-              preset: "ASA Premium"
-
-              # Project configuration
-              project: Replicon-${{ github.event.repository.name }}
-              scanners: sast
-              incremental: true
-              break_build: false
-
-              # Scan parameters and thresholds
-              params: >-
-                --namespace=${{ github.repository_owner}}
-                --checkmarx.settings-override=true
-                --repo-name=${{ github.event.repository.name}}
-                --branch=${{ github.ref_name || github.head_ref}}
-                --cx-flow.filterSeverity
-                --cx-flow.thresholds.high=1
-                --cx-flow.thresholds.medium=1
-                --cx-flow.scan-resubmit=true
-                ${{ github.event.number && format('--merge-id={0}', github.event.number)}}
-
-  checkmarx-scheduled-scan:
-        name: Checkmarx scheduled SAST Scan
-        runs-on: ubuntu-latest
-        concurrency:
-            group: checkmarx-scheduled-scan
-            cancel-in-progress: true
-        timeout-minutes: 360
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-
-        steps:
-          - name: Checkout Code
-            uses: actions/checkout@v4
-            with:
-              ref: ${{ github.event.repository.default_branch }}
-
-          - name: Run Checkmarx SAST Scan
-            uses: checkmarx-ts/checkmarx-cxflow-github-action@v2.3
-            with:
-              # Connection parameters
-              checkmarx_url: https://cmxext.deltek.com
-              checkmarx_username: ${{ secrets.CHECKMARX_USERNAME }}
-              checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
-              checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
-              team: "/CxServer/Security/Deltek/Replicon"
-              preset: "ASA Premium"
-
-              # Project configuration
-              project: Replicon-${{ github.event.repository.name }}
-              scanners: sast
-              incremental: false
-              break_build: false
-
-              # Scan parameters and thresholds
-              params: >-
-                --namespace=${{ github.repository_owner}}
-                --checkmarx.settings-override=true
-                --repo-name=${{ github.event.repository.name}}
-                --branch=${{ github.event.repository.default_branch }}
-                --cx-flow.filterSeverity
-                --cx-flow.thresholds.high=1
-                --cx-flow.thresholds.medium=1
-                --cx-flow.scan-resubmit=true
- 

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -27,6 +27,7 @@ jobs:
                 checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
                 checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
                 team: "/CxServer/Security/Deltek/Replicon"
+                preset: "ASA Premium"
                 # Project configuration
                 project: Replicon-${{ github.event.repository.name }}
                 scanners: sast
@@ -64,6 +65,7 @@ jobs:
                 checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
                 checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
                 team: "/CxServer/Security/Deltek/Replicon"
+                preset: "ASA Premium"
                 # Project configuration
                 project: Replicon-${{ github.event.repository.name }}
                 scanners: sast

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -12,6 +12,9 @@ jobs:
   checkmarx-scan:
         name: Checkmarx SAST Scan
         runs-on: ubuntu-latest
+        concurrency:
+            group: checkmarx-${{ github.head_ref || github.ref }}
+            cancel-in-progress: true
         timeout-minutes: 90
         if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
 
@@ -51,6 +54,9 @@ jobs:
   checkmarx-scheduled-scan:
         name: Checkmarx scheduled SAST Scan
         runs-on: ubuntu-latest
+        concurrency:
+            group: checkmarx-scheduled-scan
+            cancel-in-progress: true
         timeout-minutes: 360
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
 

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -4,17 +4,20 @@ on:
     branches:
     - main
     - master
+  schedule:
+    # Run on the 28th of every month at 2 AM UTC (safe for all months)
+    - cron: '0 2 28 * *'
+  workflow_dispatch:
 name: Checkmarx SAST Scan
 jobs:
   checkmarx-scan:
         name: Checkmarx SAST Scan
         runs-on: ubuntu-latest
-        timeout-minutes: 30
-
+        timeout-minutes: 90
+        if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'  # Skip this job on scheduled runs
         steps:
             - name: Checkout Code
               uses: actions/checkout@v4
-
             - name: Run Checkmarx SAST Scan
               uses: checkmarx-ts/checkmarx-cxflow-github-action@v2.3
               with:
@@ -24,14 +27,12 @@ jobs:
                 checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
                 checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
                 team: "/CxServer/Security/Deltek/Replicon"
-
                 # Project configuration
                 project: Replicon-${{ github.event.repository.name }}
                 scanners: sast
                 # bug_tracker: GitHub
-                incremental: false
+                incremental: true
                 break_build: false
-
                 # Scan parameters and thresholds
                 params: >-
                   --namespace=${{ github.repository_owner}}
@@ -44,3 +45,38 @@ jobs:
                   --cx-flow.scan-resubmit=true
                   ${{ github.event.number && format('--merge-id={0}', github.event.number)}}
                   
+  checkmarx-scheduled-scan:
+        name: Checkmarx scheduled SAST Scan
+        runs-on: ubuntu-latest
+        timeout-minutes: 360
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        steps:
+            - name: Checkout Code
+              uses: actions/checkout@v4
+              with:
+                ref: ${{ github.event.repository.default_branch }}
+            - name: Run Checkmarx SAST Scan
+              uses: checkmarx-ts/checkmarx-cxflow-github-action@v2.3
+              with:
+                # Connection parameters
+                checkmarx_url: https://cmxext.deltek.com
+                checkmarx_username: ${{ secrets.CHECKMARX_USERNAME }}
+                checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
+                checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
+                team: "/CxServer/Security/Deltek/Replicon"
+                # Project configuration
+                project: Replicon-${{ github.event.repository.name }}
+                scanners: sast
+                # bug_tracker: GitHub
+                incremental: false
+                break_build: false
+                # Scan parameters and thresholds
+                params: >-
+                  --namespace=${{ github.repository_owner}}
+                  --checkmarx.settings-override=true
+                  --repo-name=${{ github.event.repository.name}}
+                  --branch=${{ github.event.repository.default_branch }}
+                  --cx-flow.filterSeverity
+                  --cx-flow.thresholds.high=1
+                  --cx-flow.thresholds.medium=1
+                  --cx-flow.scan-resubmit=true

--- a/.github/workflows/checkmarx.yml
+++ b/.github/workflows/checkmarx.yml
@@ -1,12 +1,11 @@
 on:
-  pull_request: {}
+  pull_request:
   push:
     branches:
     - main
     - master
   schedule:
-    # Run on the 28th of every month at 2 AM UTC (safe for all months)
-    - cron: '0 2 28 * *'
+    - cron: '0 7 * * 6'
   workflow_dispatch:
 name: Checkmarx SAST Scan
 jobs:
@@ -14,71 +13,78 @@ jobs:
         name: Checkmarx SAST Scan
         runs-on: ubuntu-latest
         timeout-minutes: 90
-        if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'  # Skip this job on scheduled runs
+        if: github.event_name != 'schedule' && github.event_name != 'workflow_dispatch'
+
         steps:
-            - name: Checkout Code
-              uses: actions/checkout@v4
-            - name: Run Checkmarx SAST Scan
-              uses: checkmarx-ts/checkmarx-cxflow-github-action@v2.3
-              with:
-                # Connection parameters
-                checkmarx_url: https://cmxext.deltek.com
-                checkmarx_username: ${{ secrets.CHECKMARX_USERNAME }}
-                checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
-                checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
-                team: "/CxServer/Security/Deltek/Replicon"
-                preset: "ASA Premium"
-                # Project configuration
-                project: Replicon-${{ github.event.repository.name }}
-                scanners: sast
-                # bug_tracker: GitHub
-                incremental: true
-                break_build: false
-                # Scan parameters and thresholds
-                params: >-
-                  --namespace=${{ github.repository_owner}}
-                  --checkmarx.settings-override=true
-                  --repo-name=${{ github.event.repository.name}}
-                  --branch=${{ github.ref_name || github.head_ref}}
-                  --cx-flow.filterSeverity
-                  --cx-flow.thresholds.high=1
-                  --cx-flow.thresholds.medium=1
-                  --cx-flow.scan-resubmit=true
-                  ${{ github.event.number && format('--merge-id={0}', github.event.number)}}
-                  
+          - name: Checkout Code
+            uses: actions/checkout@v4
+
+          - name: Run Checkmarx SAST Scan
+            uses: checkmarx-ts/checkmarx-cxflow-github-action@v2.3
+            with:
+              # Connection parameters
+              checkmarx_url: https://cmxext.deltek.com
+              checkmarx_username: ${{ secrets.CHECKMARX_USERNAME }}
+              checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
+              checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
+              team: "/CxServer/Security/Deltek/Replicon"
+              preset: "ASA Premium"
+
+              # Project configuration
+              project: Replicon-${{ github.event.repository.name }}
+              scanners: sast
+              incremental: true
+              break_build: false
+
+              # Scan parameters and thresholds
+              params: >-
+                --namespace=${{ github.repository_owner}}
+                --checkmarx.settings-override=true
+                --repo-name=${{ github.event.repository.name}}
+                --branch=${{ github.ref_name || github.head_ref}}
+                --cx-flow.filterSeverity
+                --cx-flow.thresholds.high=1
+                --cx-flow.thresholds.medium=1
+                --cx-flow.scan-resubmit=true
+                ${{ github.event.number && format('--merge-id={0}', github.event.number)}}
+
   checkmarx-scheduled-scan:
         name: Checkmarx scheduled SAST Scan
         runs-on: ubuntu-latest
         timeout-minutes: 360
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+
         steps:
-            - name: Checkout Code
-              uses: actions/checkout@v4
-              with:
-                ref: ${{ github.event.repository.default_branch }}
-            - name: Run Checkmarx SAST Scan
-              uses: checkmarx-ts/checkmarx-cxflow-github-action@v2.3
-              with:
-                # Connection parameters
-                checkmarx_url: https://cmxext.deltek.com
-                checkmarx_username: ${{ secrets.CHECKMARX_USERNAME }}
-                checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
-                checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
-                team: "/CxServer/Security/Deltek/Replicon"
-                preset: "ASA Premium"
-                # Project configuration
-                project: Replicon-${{ github.event.repository.name }}
-                scanners: sast
-                # bug_tracker: GitHub
-                incremental: false
-                break_build: false
-                # Scan parameters and thresholds
-                params: >-
-                  --namespace=${{ github.repository_owner}}
-                  --checkmarx.settings-override=true
-                  --repo-name=${{ github.event.repository.name}}
-                  --branch=${{ github.event.repository.default_branch }}
-                  --cx-flow.filterSeverity
-                  --cx-flow.thresholds.high=1
-                  --cx-flow.thresholds.medium=1
-                  --cx-flow.scan-resubmit=true
+          - name: Checkout Code
+            uses: actions/checkout@v4
+            with:
+              ref: ${{ github.event.repository.default_branch }}
+
+          - name: Run Checkmarx SAST Scan
+            uses: checkmarx-ts/checkmarx-cxflow-github-action@v2.3
+            with:
+              # Connection parameters
+              checkmarx_url: https://cmxext.deltek.com
+              checkmarx_username: ${{ secrets.CHECKMARX_USERNAME }}
+              checkmarx_password: ${{ secrets.CHECKMARX_PASSWORD }}
+              checkmarx_client_secret: ${{ secrets.CHECKMARX_CLIENT_SECRET }}
+              team: "/CxServer/Security/Deltek/Replicon"
+              preset: "ASA Premium"
+
+              # Project configuration
+              project: Replicon-${{ github.event.repository.name }}
+              scanners: sast
+              incremental: false
+              break_build: false
+
+              # Scan parameters and thresholds
+              params: >-
+                --namespace=${{ github.repository_owner}}
+                --checkmarx.settings-override=true
+                --repo-name=${{ github.event.repository.name}}
+                --branch=${{ github.event.repository.default_branch }}
+                --cx-flow.filterSeverity
+                --cx-flow.thresholds.high=1
+                --cx-flow.thresholds.medium=1
+                --cx-flow.scan-resubmit=true
+ 

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+.git/
+.github/
+.gitmodules
+.idea/
+.travis.yml
+.vscode/
+test/

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replicon/dynamodb-subscriber",
   "description": "",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "author": "Andrew Ovens <andrew.ovens@replicon.com>",
   "repository": {
     "url": "git://github.com/replicon/dynamodb-subscriber.git"
@@ -11,7 +11,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "async": "~2.0.1",
+    "async": "^2.6.4",
     "aws-sdk": "^2.45.0",
     "debug": "^2.6.8",
     "ms": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,15 +11,18 @@
     "test": "mocha"
   },
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.0.0",
+    "@aws-sdk/client-dynamodb-streams": "^3.0.0",
+    "@aws-sdk/util-dynamodb": "^3.0.0",
     "async": "^2.6.4",
-    "aws-sdk": "^2.45.0",
     "debug": "^2.6.8",
     "ms": "^2.0.0",
     "tempus-fugit": "~2.3.1"
   },
   "devDependencies": {
-    "aws-sdk-mock": "~1.4.0",
+    "aws-sdk-client-mock": "^4.0.0",
     "chai": "~3.5.0",
-    "mocha": "~2.2.5"
+    "mocha": "~2.2.5",
+    "sinon": "^21.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dynamodb-subscriber",
+  "name": "@replicon/dynamodb-subscriber",
   "description": "",
   "version": "1.2.0",
   "author": "Andrew Ovens <andrew.ovens@replicon.com>",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "dynamodb-subscriber",
   "description": "",
-  "version": "1.1.2",
-  "author": "José F. Romaniello <jfromaniello@gmail.com> (http://joseoncode.com)",
+  "version": "1.2.0",
+  "author": "Andrew Ovens <andrew.ovens@replicon.com>",
   "repository": {
-    "url": "git://github.com/jfromaniello/dynamodb-subscriber.git"
+    "url": "git://github.com/replicon/dynamodb-subscriber.git"
   },
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replicon/dynamodb-subscriber",
   "description": "",
-  "version": "1.2.0",
+  "version": "1.5.0",
   "author": "Andrew Ovens <andrew.ovens@replicon.com>",
   "repository": {
     "url": "git://github.com/replicon/dynamodb-subscriber.git"


### PR DESCRIPTION
## Summary

Migrated `dynamodb-subscriber` from AWS SDK for JavaScript v2 to v3, maintaining full backward compatibility.

## Changes Made

### Production Code (`index.js`)
- ✅ Updated imports to use modular v3 packages:
  - `@aws-sdk/client-dynamodb`
  - `@aws-sdk/client-dynamodb-streams`
  - `@aws-sdk/util-dynamodb`
- ✅ Replaced `aws.DynamoDB.Converter.output()` with `unmarshall()`
- ✅ Updated client instantiation to v3 classes (`DynamoDB`, `DynamoDBStreams`)
- ✅ Kept v2-compatible API method calls (e.g., `client.describeStream()`) for seamless migration

### Test Updates
- ✅ Updated test mocking from `aws-sdk-mock` (v2 only) to `Sinon` (v3 compatible)
- ✅ All 3 tests passing

### Dependencies
**Removed:**
- `aws-sdk` ^2.45.0
- `aws-sdk-mock` ~1.4.0

**Added:**
- `@aws-sdk/client-dynamodb` ^3.0.0
- `@aws-sdk/client-dynamodb-streams` ^3.0.0
- `@aws-sdk/util-dynamodb` ^3.0.0
- `sinon` ^21.0.1 (dev dependency)

## Backward Compatibility ✅

**External API is 100% unchanged:**
- ✅ All exports preserved (`DynamoDBSubscriber`, `.Stream`)
- ✅ Constructor parameters unchanged
- ✅ Method signatures unchanged (`start()`, `stop()`)
- ✅ EventEmitter interface unchanged (`on('record')`, `on('error')`)
- ✅ Event signatures unchanged

**Verified:**
```javascript
// All of these still work exactly as before
const subscriber = new DynamoDBSubscriber({ arn, interval });
subscriber.on('record', (record, keys) => { ... });
subscriber.start();
subscriber.stop();

const stream = DynamoDBSubscriber.Stream({ arn, interval });
stream.pipe(...);
```

## Testing

- ✅ All existing tests pass (3/3)
- ✅ Public API verification passed
- ✅ No breaking changes to consumers

## Benefits

- ✅ Modular imports reduce bundle size
- ✅ Better TypeScript support
- ✅ Future-proof (AWS SDK v2 is in maintenance mode)
- ✅ Improved tree-shaking capabilities

## Next Steps

After this PR is merged:
- Update dependent repositories to use latest version
- Monitor for any issues in downstream consumers

## JIRA

https://replicon.atlassian.net/browse/SF-2432

---

🤖 Generated with assistance from Claude Code